### PR TITLE
Remove unnecessary vscode extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
   "extensions": [
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "streetsidesoftware.code-spell-checker",
     "ms-azuretools.vscode-docker"
   ]
 }


### PR DESCRIPTION
If you want to use this, you may use `remote.containers.defaultExtensions`